### PR TITLE
fix: ignore infinite metrics value

### DIFF
--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/InfluxdbReporter.java
@@ -109,7 +109,9 @@ public class InfluxdbReporter extends AbstractReporter<MeasurementInfo> implemen
 		report.retentionPolicy(retentionPolicy);
 		try {
 			for (Map.Entry<Gauge<?>, MeasurementInfo> entry : gauges.entrySet()) {
-				report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				try {
+					report.point(MetricMapper.map(entry.getValue(), timestamp, entry.getKey()));
+				} catch (RuntimeException ignore) {}
 			}
 
 			for (Map.Entry<Counter, MeasurementInfo> entry : counters.entrySet()) {

--- a/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MetricMapper.java
+++ b/flink-metrics/flink-metrics-influxdb/src/main/java/org/apache/flink/metrics/influxdb/MetricMapper.java
@@ -35,6 +35,11 @@ class MetricMapper {
 		Point.Builder builder = builder(info, timestamp);
 		Object value = gauge.getValue();
 		if (value instanceof Number) {
+			if (value instanceof Double && Double.isInfinite((Double) value)) {
+				throw new RuntimeException("get infinite type double value");
+			} else if (value instanceof Float && Float.isInfinite((Float) value)) {
+				throw new RuntimeException("get infinite type float value");
+			}
 			builder.addField("value", (Number) value);
 		} else {
 			builder.addField("value", String.valueOf(value));


### PR DESCRIPTION
influxdb 不支持 inf 类型的数据，flink 的 metrics 会产生挺多这样的数据，直接上的话 taskManager 会一直抛异常。

目前已经有 issue 提到了这个事情，https://issues.apache.org/jira/browse/FLINK-12147 ，不过看上去好像 flink 社区想推 influxdb 做一些改动支持 inf，感觉得等挺久的，这边先做一个 workaround 。